### PR TITLE
CET-18547 Includes closedDate into PullRequest object to avoid additi…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = io.github.cdancy
-version = 3.1.2-CORTEX
+version = 3.2.6-CORTEX
 
 artifactoryURL = http://127.0.0.1:8080/artifactory
 artifactoryUser = admin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = io.github.cdancy
-version = 3.2.6-CORTEX
+version = 3.1.3-CORTEX
 
 artifactoryURL = http://127.0.0.1:8080/artifactory
 artifactoryUser = admin

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/pullrequest/PullRequest.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/pullrequest/PullRequest.java
@@ -50,6 +50,9 @@ public abstract class PullRequest implements ErrorsHolder, LinksHolder {
 
     public abstract boolean closed();
 
+    @Nullable
+    public abstract Long closedDate();
+
     public abstract long createdDate();
 
     public abstract long updatedDate();
@@ -75,47 +78,49 @@ public abstract class PullRequest implements ErrorsHolder, LinksHolder {
     PullRequest() {
     }
 
-    @SerializedNames({ "id", "version", "title", "description", 
-            "state", "open", "closed", "createdDate", 
-            "updatedDate", "fromRef", "toRef", "locked", 
-            "author", "reviewers", "participants", "properties", 
+    @SerializedNames({ "id", "version", "title", "description",
+            "state", "open", "closed", "closedDate", "createdDate",
+            "updatedDate", "fromRef", "toRef", "locked",
+            "author", "reviewers", "participants", "properties",
             "links", "errors" })
-    public static PullRequest create(final int id, 
-            final int version, 
-            final String title, 
-            final String description, 
-            final String state, 
+    public static PullRequest create(final int id,
+            final int version,
+            final String title,
+            final String description,
+            final String state,
             final boolean open,
-            final boolean closed, 
-            final long createdDate, 
-            final long updatedDate, 
+            final boolean closed,
+            final Long closedDate,
+            final long createdDate,
+            final long updatedDate,
             final Reference fromRef,
-            final Reference toRef, 
-            final boolean locked, 
-            final Person author, 
+            final Reference toRef,
+            final boolean locked,
+            final Person author,
             final List<Person> reviewers,
-            final List<Person> participants, 
-            final Properties properties, 
+            final List<Person> participants,
+            final Properties properties,
             final Links links,
             final List<Error> errors) {
-        
-        return new AutoValue_PullRequest(BitbucketUtils.nullToEmpty(errors), 
-                links, 
-                id, 
-                version, 
-                title, 
-                description, 
-                state, 
-                open, 
-                closed, 
+
+        return new AutoValue_PullRequest(BitbucketUtils.nullToEmpty(errors),
+                links,
+                id,
+                version,
+                title,
+                description,
+                state,
+                open,
+                closed,
+                closedDate,
                 createdDate,
-                updatedDate, 
-                fromRef, 
-                toRef, 
-                locked, 
-                author, 
-                BitbucketUtils.nullToEmpty(reviewers), 
-                BitbucketUtils.nullToEmpty(participants), 
+                updatedDate,
+                fromRef,
+                toRef,
+                locked,
+                author,
+                BitbucketUtils.nullToEmpty(reviewers),
+                BitbucketUtils.nullToEmpty(participants),
                 properties);
     }
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -783,7 +783,7 @@ public final class BitbucketFallbacks {
 
     public static PullRequest createPullRequestFromErrors(final List<Error> errors) {
         return PullRequest.create(-1, -1, null, null, null,
-                false, false, 0, 0, null,
+                false, false, null, 0, 0, null,
                 null, false, null, null, null,
                 null, null, errors);
     }


### PR DESCRIPTION
Adds `closedDate` field to PullRequest data model. It's supported by [Bitbucket data center REST API](https://developer.atlassian.com/server/bitbucket/rest/v906/api-group-pull-requests/#api-api-latest-projects-projectkey-repos-repositoryslug-pull-requests-get). 
This way we will avoid making additional calls to PR activity endpoint to fetch actual closed date of a PR.  